### PR TITLE
Fix circular references on examples

### DIFF
--- a/packages/insomnia-importers/src/importers/openapi-3.ts
+++ b/packages/insomnia-importers/src/importers/openapi-3.ts
@@ -781,6 +781,6 @@ export const convert: Converter = async rawData => {
   ];
 };
 
-function isReferenceObject(items: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject) {
+function isReferenceObject(items: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject): items is OpenAPIV3.ReferenceObject {
   return Object.keys(items).includes('$ref');
 }

--- a/packages/insomnia-importers/src/importers/openapi-3.ts
+++ b/packages/insomnia-importers/src/importers/openapi-3.ts
@@ -515,9 +515,25 @@ const generateParameterExample = (schema: OpenAPIV3.SchemaObject | string) => {
 
       if (properties) {
         for (const propertyName of Object.keys(properties)) {
-          example[propertyName] = generateParameterExample(
-            properties[propertyName] as OpenAPIV3.SchemaObject,
-          );
+          const propertySchema = properties[
+            propertyName
+          ] as OpenAPIV3.SchemaObject;
+
+          if (
+            propertySchema.type === "array" &&
+            !isReferenceObject(propertySchema.items) &&
+            propertySchema.items.type === "object" &&
+            propertySchema.items.title === schema.title
+          ) {
+            console.log("DEBUG: Recursion found on element array");
+          } else if (
+            propertySchema.type === "object" &&
+            propertySchema.title === schema.title
+          ) {
+            console.log("DEBUG: Recursion found on element object");
+          } else {
+            example[propertyName] = generateParameterExample(propertySchema);
+          }
         }
       }
 
@@ -764,3 +780,7 @@ export const convert: Converter = async rawData => {
     ...endpoints,
   ];
 };
+
+function isReferenceObject(items: OpenAPIV3.SchemaObject | OpenAPIV3.ReferenceObject) {
+  return Object.keys(items).includes('$ref');
+}


### PR DESCRIPTION
- Remove circular references on OpenAPI 3 spec

Not 100% sure what to do on those cases, the example should still include the property (right now excluded). Maybe a string with ``[this]``.

Also checking the ``title`` might not be the best approach. Not sure...